### PR TITLE
useSelector redux hook

### DIFF
--- a/src/components/ExchangeRate.js
+++ b/src/components/ExchangeRate.js
@@ -1,15 +1,25 @@
 import { useState, useCallback, useEffect } from "react";
+// redux
+import { useSelector } from "react-redux";
+// components
 import { RateTable } from "./RateTable";
 import { CurrencyCodePicker } from "./CurrencyCodePicker";
 import { AmountField } from "./AmountField";
+// api
 import { getExchangeRates } from "../api";
 
 const supportedCurrencies = ["USD", "EUR", "JPY", "CAD", "GBP", "MXN"];
 
 export function ExchangeRate() {
-  const [amount, setAmount] = useState("1.50");
-  const [currencyCode, setCurrencyCode] = useState("USD");
+  // const [amount, setAmount] = useState("1.50");
+  // const [currencyCode, setCurrencyCode] = useState("USD");
   const [currencyData, setCurrencyData] = useState({ USD: 1.0 });
+
+  const amount = useSelector((state) => state.amount);
+  const currencyCode = useSelector((state) => state.currencyCode);
+
+  const setAmount = () => { };
+  const setCurrencyCode = () => { };
 
   // fetch the exchange rates each time currency code changes
   useEffect(() => {

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,7 @@
 import { createStore } from "redux";
 
 const initialState = {
-  amount: "12.00",
+  amount: "18.70",
   currencyCode: "USD"
 }
 


### PR DESCRIPTION
- import `{ useSelector }` from 'react-redux'. Then, comment out the first two `useState `lines
- type` const amount = useSelector((state) => state.amount)`
- we'll do the same thing for _currencyCode_`, const currencyCode = useSelector((state) => state.currencyCode)`
- the `useSelector` hook takes a function which receives as its first argument state
- and then it allows you to return from that which part of the **state** that you want
- all of our state right now is defined in the file called store.js
- we can access `state.amount` or `state.currencyCode`.  Anything that exists in this object, we can access
- you see over here our app is now complaining about `setCurrencyCode` and `setAmount` failing
- for now, we're just going to put in two empty functions.` setAmount = function()`
- and `setCurrencyCode = function()`, which should appease our application for the time being
- We've now replaced `useState `to grab the current version of amount and _currencyCode_ with `useSelector`