### PR TITLE
Finished with add logic to reducers

### DIFF
--- a/src/components/CurrencyCodePicker.js
+++ b/src/components/CurrencyCodePicker.js
@@ -1,9 +1,10 @@
 // redux
-import { useDispatch } from "react-redux";
-import { changeCurrencyCode } from "../store/rates";
+import { useDispatch, useSelector } from "react-redux";
+import { changeCurrencyCode, getSupportedCurrencies } from "../store/rates";
 
-export const CurrencyCodePicker = ({ supportedCurrencies, currencyCode }) => {
+export const CurrencyCodePicker = ({ currencyCode }) => {
   const dispatch = useDispatch();
+  const supportedCurrencies = useSelector(getSupportedCurrencies);
 
   const onChange = (e) => {
     dispatch(changeCurrencyCode(e.target.value));

--- a/src/components/ExchangeRate.js
+++ b/src/components/ExchangeRate.js
@@ -4,8 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   getAmount,
   getCurrencyCode,
-  getCurrencyData,
-  supportedCurrencies
+  getCurrencyData
 } from "../store/rates";
 // components
 import { RateTable } from "./RateTable";
@@ -28,7 +27,6 @@ export const ExchangeRate = () => {
         <h1 className="ExchangeRate-header">
           Exchange Rates{" "}
           <CurrencyCodePicker
-            supportedCurrencies={supportedCurrencies}
             currencyCode={currencyCode}
           />
         </h1>

--- a/src/store/rates.js
+++ b/src/store/rates.js
@@ -1,11 +1,10 @@
 import { getExchangeRates } from "../api";
 
-export const supportedCurrencies = ["USD", "EUR", "JPY", "CAD", "GBP", "MXN"];
-
 const initialState = {
   amount: "18.70",
   currencyCode: "USD",
-  currencyData: { USD: 1.0 }
+  currencyData: { USD: 1.0 },
+  supportedCurrencies: ["USD", "EUR", "JPY", "CAD", "GBP", "MXN"]
 }
 
 export const ratesReducer = (state = initialState, action) => {
@@ -14,8 +13,10 @@ export const ratesReducer = (state = initialState, action) => {
       return { ...state, amount: action.payload };
     case CURRENCY_CODE_CHANGED:
       return { ...state, currencyCode: action.payload };
-    case "rates/ratesReceived":
-      return { ...state, currencyData: action.payload };
+    case "rates/ratesReceived": {
+      const codes = Object.keys(action.payload).concat(state.currencyCode);
+      return { ...state, currencyData: action.payload, supportedCurrencies: codes };
+    }
     default:
       return state;
   }
@@ -25,6 +26,7 @@ export const ratesReducer = (state = initialState, action) => {
 export const getAmount = (state) => state.rates.amount;
 export const getCurrencyCode = (state) => state.rates.currencyCode;
 export const getCurrencyData = (state) => state.rates.currencyData;
+export const getSupportedCurrencies = (state) => state.rates.supportedCurrencies;
 
 // action types
 export const AMOUNT_CHANGED = "rates/amountChanged";
@@ -37,12 +39,14 @@ export const changeAmount = (amount) => ({
 });
 
 export function changeCurrencyCode(currencyCode) {
-  return function changeCurrencyCodeThunk(dispatch) {
+  return function changeCurrencyCodeThunk(dispatch, getState) {
+    const state = getState();
+    const supportedCurrencies = getSupportedCurrencies(state);
     dispatch({
-      type: AMOUNT_CHANGED,
+      type: CURRENCY_CODE_CHANGED,
       payload: currencyCode
     });
-    getExchangeRates(currencyCode, supportedCurrencies).then(rates => {
+    getExchangeRates(currencyCode, supportedCurrencies).then((rates) => {
       dispatch({
         type: "rates/ratesReceived",
         payload: rates


### PR DESCRIPTION
- we import `supportedCurrencies` and then pass it directly into `currencyCodePicker` => instead, let's put` supportedCurrencies` in our **Redux** store
- copy the `supportedCurrencies` array down here into _initial_ state, getting rid of the exported **variable**
- let's add a _selector_ , `export const getSupportedCurrencies = state(state.rates.supportedcurrencies)`
- import the `useSelector` method and type `const supportedCurrencies = useSelector`
- then, we can also import `getSupportedCurrencie`s
- `supportedCurrencies` was also being used inside the change currency code **thunk**
- one solution for that would be to use `getState()` here and save the state into a **variable** => then, grab the supported _currencies_  from the state using our `selector`, `getSupportedCurrencies(state)`
- while it's fine to send in an initial **hardcoded** list to populate our dropdown and to send to the API, once we get the API call back, it'll be helpful to update this list to ensure that only currency codes found in our response are actually included in the list
- we're going to wrap this case in _curly braces_ => the _curly braces_ will allow us to have **variables** who only have scope for this block and won't affect anything else in this function, or even in this switch statement
- we can type `const codes = {object.keys(action.payload)}`
- that gives us a list of the new _currency codes_, and we can add those here, `supportedCurrencies: codes`
- we have to add that into our list => we can do that by doing `object.keys.concat`
- then, we need to get the `current currency code` => we already have access to state, so we can say `state.currencyCode`
- refreshing the page, you'll notice that we have _one, two, three, four, five_ here => _one, two, three, four, five, six_ here, which is correct
- if I click through the different _codes_, they are updating